### PR TITLE
Conan support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@
 cmake_minimum_required(VERSION 3.8)
 project(xeus)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 set(XEUS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(XEUS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -68,52 +71,6 @@ else()
     set(CPPZMQ_TARGET_NAME cppzmq)
     set(OPENSSL_USE_STATIC_LIBS OFF)
 endif()
-
-# Dependencies
-# ============
-
-set(nlohmann_json_REQUIRED_VERSION 3.2.0)
-set(xtl_REQUIRED_VERSION 0.5)
-set(cppzmq_REQUIRED_VERSION 4.4.1)
-set(zeromq_REQUIRED_VERSION 4.3.2)
-
-if (NOT TARGET nlohmann_json)
-    find_package(nlohmann_json ${nlohmann_json_REQUIRED_VERSION} REQUIRED)
-endif ()
-
-if (NOT TARGET xtl)
-    find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
-endif ()
-
-if (NOT TARGET cppzmq AND NOT TARGET cppzmq-static)
-    find_package(cppzmq ${cppzmq_REQUIRED_VERSION} REQUIRED)
-endif ()
-
-if (NOT TARGET libzmq AND NOT TARGET libzmq-static)
-    if (WIN32)
-        find_package(zeromq ${zeromq_REQUIRED_VERSION} REQUIRED)
-    else ()
-        find_package(zeromq ${zeromq_REQUIRED_VERSION} QUIET)
-
-        if (NOT ZeroMQ_FOUND)
-            message(STATUS "CMake libzmq package not found, trying again with pkg-config")
-            find_package(PkgConfig)
-            pkg_check_modules(ZeroMQ libzmq>=${zeromq_REQUIRED_VERSION} REQUIRED)
-            set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
-            find_library(ZeroMQ_LIBRARY NAMES libzmq.so libzmq.dylib libzmq.dll
-                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-            find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq-static.a libzmq.a libzmq.dll.a
-                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-            message(STATUS "STATIC_LIBRARY" {ZeroMQ_LIBRARY})
-            message(STATUS "STATIC_STATIC_LIBRARY" {ZeroMQ_STATIC_LIBRARY})
-         endif ()
-    endif ()
-endif ()
-
-if (NOT DEFINED OPENSSL_LIBRARY)
-    set(OPENSSL_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
-    find_package(OpenSSL REQUIRED)
-endif ()
 
 # Source files
 # ============
@@ -233,38 +190,7 @@ macro(xeus_create_target target_name linkage output_name)
         $<INSTALL_INTERFACE:include>
     )
 
-    target_link_libraries(
-        ${target_name}
-        PUBLIC ${CPPZMQ_TARGET_NAME}
-        PUBLIC nlohmann_json::nlohmann_json
-        PUBLIC xtl
-    )
-
-    target_link_libraries(${target_name} PUBLIC OpenSSL::Crypto)
-
-    if (NOT MSVC)
-        if (APPLE)
-            target_link_libraries(${target_name} PUBLIC "-framework CoreFoundation")
-        else ()
-            if (XEUS_STATIC_DEPENDENCIES)
-                find_path(LIBUUID_INCLUDE_DIR uuid.h PATH_SUFFIXES uuid)
-                find_library(LIBUUID_LIBRARY libuuid.a)
-                target_include_directories(${target_name} PRIVATE ${LIBUUID_INCLUDE_DIR})
-                target_link_libraries(${target_name} PUBLIC ${LIBUUID_LIBRARY})
-            
-                # Explicitly finds and links with libsodium.a
-                # because it is not exported as a dependency by
-                # the static build of libzmq. Remove this when
-                # it is fixed upstream.
-                set(sodium_USE_STATIC_LIBS ON)
-                find_package(sodium REQUIRED)
-                target_link_libraries(${target_name} PUBLIC ${sodium_LIBRARY_RELEASE})
-            else ()
-                find_package(LibUUID REQUIRED)
-                target_link_libraries(${target_name} PUBLIC LibUUID::LibUUID)
-            endif ()
-        endif ()
-    endif ()
+    conan_target_link_libraries(${target_name})
 
     set_target_properties(
         ${target_name}

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,11 +25,13 @@ class XeusConan(ConanFile):
         cmake.test()
 
     def package(self):
-        self.copy("*.hpp", dst="include", src="hello")
-        self.copy("*xeus.lib", dst="lib", keep_path=False)
-        self.copy("*.dll", dst="bin", keep_path=False)
-        self.copy("*.so", dst="lib", keep_path=False)
-        self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.hpp", dst="include", src="include")
+        # Not pretty: (sorry, but I just wanted static lib!)
+        if False:
+            self.copy("*xeus.lib", dst="lib", keep_path=False)
+            self.copy("*.dll", dst="lib", keep_path=False)
+            self.copy("*.so", dst="lib", keep_path=False)
+            self.copy("*.dylib", dst=".", keep_path=False)
         self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,37 @@
+import os
+from conans import ConanFile, CMake
+
+class XeusConan(ConanFile):
+    name = "xeus"
+    version = "0.2.38"
+    settings = "os", "compiler", "build_type", "arch"
+    requires = (
+        "zmq/4.3.2@bincrafters/stable",
+        "cppzmq/4.6.0@_/_",
+        "xtl/0.6.12@_/_",
+        "openssl/1.0.2u@_/_",
+        "nlohmann_json/3.7.3@_/_",
+        "libuuid/1.0.3@_/_",
+    )
+    generators = "cmake", "virtualrunenv"
+    build_policy = "missing" 
+    exports_sources = "*"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.verbose = True
+        cmake.configure()
+        cmake.build()
+        cmake.test()
+
+    def package(self):
+        self.copy("*.hpp", dst="include", src="hello")
+        self.copy("*xeus.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["xeus"]
+


### PR DESCRIPTION
With absolutely no ego involved, I would like to share this very brutish implementation of support for conan. I say brutish because:

- I performed no testing other than the platform that I use, which is Ubuntu.
- I clobber the `CMakeLists.txt` with conan's dependencies. 
- I simply copied the the example `conanfile.py` in Conan's documentation and tweaked.
- No tests, even though tests exist. Would be trivial to add.

That said, on my machine at least, this pulls in all the dependencies from Conan, builds them, and offers them as a library for use in other projects. E.g. you can create a new "userland" project using Conan and require xeus itself (now a Conan repo).

An example of a "userland" (i.e. from a program that uses Xeus in conan mode in order to create a new jupyter kernel) can be found [in the conanfile for my (very early-stage) programming language, bullet](https://github.com/seertaak/bt/blob/master/conanfile.py).

You can test this version of xeus by:

- installing conan (`pip install conan`)
- doing whatever stuff conan makes you do in order not to point to gcc (at least for me). It's in `~/.conan/profiles/default`, also see `~/.conan/settings.yml` to make sure conan knows about the version of your compiler. (Especially important if like me you use C++20.)
- then after cloning my version of the repo, `cd` to base directory and type (I assume unix here but should work for at least MacOS -- Windows ought to work but you may need to go through the *super* painful hoop of installing clang for windows. YMMV). 
```bash
$ conan install . -if build   # install (using the way of the barbarian) OpenSSL, xtl, etc...
$ conan build . -bf build   # build the project. Creates the libxeus.a file.
$ conan create . '_/_'       # locally installs this new package
```
After doing these steps successfully, you should be able to include the Xeus conan project following the afore-mentioned *Bullet* example.

Feel free to completely disregard this proposal. 

EDIT: The CI builds are failing because they lack the calls detailed above (`conan install ...` etc.).
