### PR TITLE
Allow building both static and dynamic with static dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - os: linux
     - os: linux
-      env: XEUS_STATIC_DEPENDENCIES=1 
+      env: XEUS_STATIC_DEPENDENCIES=1 XEUS_BUILD_SHARED_LIBS=0 
     - os: osx
       osx_image: xcode8
       compiler: clang
@@ -41,12 +41,13 @@ install:
     # Build
     - mkdir build
     - pushd build
-    - source activate root
     - if [[ "$XEUS_STATIC_DEPENDENCIES" == 1 ]]; then
-        cmake -DXEUS_DOWNLOAD_GTEST=ON -DCMAKE_INSTALL_PREFIX=$HOME/miniconda -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DXEUS_STATIC_DEPENDENCIES=ON ..;
-      else
-        cmake -DXEUS_DOWNLOAD_GTEST=ON -DCMAKE_INSTALL_PREFIX=$HOME/miniconda -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX ..;
+        CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DXEUS_STATIC_DEPENDENCIES=ON";
       fi
+    - if [[ "$XEUS_BUILD_SHARED_LIBS" == 0 ]]; then
+        CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DXEUS_BUILD_SHARED_LIBS=OFF";
+      fi
+    - cmake -DCMAKE_INSTALL_PREFIX=$HOME/miniconda -DXEUS_DOWNLOAD_GTEST=ON -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX ${CMAKE_EXTRA_ARGS} ..
     - make -j2
     - make install
     - popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ option(XEUS_DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
 if (XEUS_STATIC_DEPENDENCIES)
     set(CPPZMQ_TARGET_NAME cppzmq-static)
     set(OPENSSL_USE_STATIC_LIBS ON)
-    set(XEUS_BUILD_SHARED_LIBS OFF)
 else()
     set(CPPZMQ_TARGET_NAME cppzmq)
     set(OPENSSL_USE_STATIC_LIBS OFF)
@@ -192,16 +191,21 @@ include(CheckCXXCompilerFlag)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-if (NOT XEUS_BUILD_SHARED_LIBS AND NOT XEUS_BUILD_STATIC_LIBS)
-    set(XEUS_BUILD_STATIC_LIBS ON)
-endif ()
-
 if (NOT APPLE)
     set(CMAKE_SKIP_BUILD_RPATH FALSE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif ()
 
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib; ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
+if (XEUS_STATIC_DEPENDENCIES AND NOT MSVC AND NOT APPLE)
+	# Explicitly finds and links with libsodium.a
+	# because it is not exported as a dependency by
+	# the static build of libzmq. Remove this when
+	# it is fixed upstream.
+	set(sodium_USE_STATIC_LIBS ON)
+	find_package(sodium REQUIRED)
+endif ()
 
 macro(xeus_create_target target_name linkage output_name)
     string(TOUPPER "${linkage}" linkage_upper)
@@ -250,14 +254,7 @@ macro(xeus_create_target target_name linkage output_name)
                 find_path(LIBUUID_INCLUDE_DIR uuid.h PATH_SUFFIXES uuid)
                 find_library(LIBUUID_LIBRARY libuuid.a)
                 target_include_directories(${target_name} PRIVATE ${LIBUUID_INCLUDE_DIR})
-                target_link_libraries(${target_name} PUBLIC ${LIBUUID_LIBRARY})
-            
-                # Explicitly finds and links with libsodium.a
-                # because it is not exported as a dependency by
-                # the static build of libzmq. Remove this when
-                # it is fixed upstream.
-                set(sodium_USE_STATIC_LIBS ON)
-                find_package(sodium REQUIRED)
+                target_link_libraries(${target_name} PUBLIC ${LIBUUID_LIBRARY}) 
                 target_link_libraries(${target_name} PUBLIC ${sodium_LIBRARY_RELEASE})
             else ()
                 find_package(LibUUID REQUIRED)


### PR DESCRIPTION
`find_package(sodium REQUIRED)` was called both for the static and the shared build, causing the sodium target to be defined twice. 