### PR TITLE
cxx_std_11 back to private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ macro(xeus_create_target target_name linkage output_name)
     # Compilation flags
     # =================
 
-    target_compile_features(${target_name} PUBLIC cxx_std_11)
+    target_compile_features(${target_name} PRIVATE cxx_std_11)
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
         CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR


### PR DESCRIPTION
@SylvainCorlay removing it now so we don't forget it. No need to release again imo, this can wait.