### PR TITLE
Fix build error on Windows

### DIFF
--- a/src/xmessage.cpp
+++ b/src/xmessage.cpp
@@ -72,7 +72,7 @@ namespace xeus
         parse_zmq_message(metadata, m_metadata);
         parse_zmq_message(content, m_content);
 
-        while (not wire_msg.empty())
+        while (!wire_msg.empty())
         {
             m_buffers.push_back(wire_msg.pop());
         }


### PR DESCRIPTION
"not" keyword is only recognized in certain Visual Studio versions and configurations (see build error below). Fixed by using ! operator instead.

  Microsoft (R) Build Engine version 16.5.0+d4cbfca49 for .NET Framework
  Copyright (C) Microsoft Corporation. All rights reserved.

    xmessage.cpp
C:\D\SlicerJupyter_D\xeus\src\xmessage.cpp(75,16): error C2065: 'not': undeclared identifier [C:\D\SlicerJupyter_D\xeus
-build\xeus.vcxproj] [C:\D\SlicerJupyter_D\xeus.vcxproj]
C:\D\SlicerJupyter_D\xeus\src\xmessage.cpp(75,20): error C2146: syntax error: missing ')' before identifier 'wire_msg'
[C:\D\SlicerJupyter_D\xeus-build\xeus.vcxproj] [C:\D\SlicerJupyter_D\xeus.vcxproj]
C:\D\SlicerJupyter_D\xeus\src\xmessage.cpp(75,36): error C2059: syntax error: ')' [C:\D\SlicerJupyter_D\xeus-build\xeus
.vcxproj] [C:\D\SlicerJupyter_D\xeus.vcxproj]