### PR TITLE
Fixed SEPARATOR search in tcp message handling

### DIFF
--- a/src/xdap_tcp_client.cpp
+++ b/src/xdap_tcp_client.cpp
@@ -272,10 +272,10 @@ namespace xeus
                 header_pos = buffer.find(HEADER, hint);
             }
 
-            separator_pos = buffer.find(SEPARATOR, header_pos + HEADER_LENGTH);
+            hint = header_pos + HEADER_LENGTH;
+            separator_pos = buffer.find(SEPARATOR, hint);
             while(separator_pos == std::string::npos)
             {
-                hint = buffer.size();
                 append_tcp_message(buffer);
                 separator_pos = buffer.find(SEPARATOR, hint);
             }


### PR DESCRIPTION
With the current implementation, if the separator is not sent  in a single tcp frame, it is never found and the `handle_tcp_socket` method never exits.