### PR TITLE
Fix build with Sphinx 4.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,10 @@ html_theme = "sphinx_rtd_theme"
 
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
+
 def setup(app):
-    app.add_stylesheet("main_stylesheet.css")
+    app.add_css_file("main_stylesheet.css")
+
 
 extensions = ['breathe']
 breathe_projects = { 'xeus': '../xml' }
@@ -35,4 +37,3 @@ highlight_language = 'c++'
 pygments_style = 'sphinx'
 todo_include_todos = False
 htmlhelp_basename = 'xeusdoc'
-


### PR DESCRIPTION
`add_stylesheet` was deprecated in 1.8 and removed in 4.0 [1]. The replacement, `add_css_file` was added in 1.0, which is older than any version required by `breathe`.

[1] https://www.sphinx-doc.org/en/master/extdev/deprecated.html?highlight=add_stylesheet