### PR TITLE
Drop RPATH settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,12 +195,6 @@ include(CheckCXXCompilerFlag)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-if (NOT APPLE)
-    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-endif ()
-
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib; ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-
 if (XEUS_STATIC_DEPENDENCIES AND NOT MSVC AND NOT APPLE)
 	# Explicitly finds and links with libsodium.a
 	# because it is not exported as a dependency by
@@ -221,13 +215,6 @@ macro(xeus_create_target target_name linkage output_name)
     # ======
 
     add_library(${target_name} ${linkage_upper} ${XEUS_SOURCES} ${XEUS_HEADERS})
-
-    if (NOT APPLE)
-        set_target_properties(
-            ${target_name} PROPERTIES
-            BUILD_WITH_INSTALL_RPATH 1
-        )
-    endif ()
 
     target_include_directories(
         ${target_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,6 @@ include(CheckCXXCompilerFlag)
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 if (NOT APPLE)
-    set(CMAKE_SKIP_BUILD_RPATH FALSE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif ()
 
@@ -223,12 +222,7 @@ macro(xeus_create_target target_name linkage output_name)
 
     add_library(${target_name} ${linkage_upper} ${XEUS_SOURCES} ${XEUS_HEADERS})
 
-    if (APPLE)
-        set_target_properties(
-            ${target_name} PROPERTIES
-            MACOSX_RPATH ON
-        )
-    else ()
+    if (NOT APPLE)
         set_target_properties(
             ${target_name} PROPERTIES
             BUILD_WITH_INSTALL_RPATH 1


### PR DESCRIPTION
When we install this system-wide, we explicitly _don't_ want RPATH set, as it breaks the search path to have default linker paths on it. It makes sense to do so for custom library search paths, but not the default (which is what this is doing, since xeus has no private libraries.)

If you need this, it seems to be environment specific. But it hasn't been clear to me why this was added in the first place, from the related PRs. Maybe the CI will break and indicate what the issue is...