### PR TITLE
struct based helpers (only for info_reply atm)

### DIFF
--- a/include/xeus/xhelper.hpp
+++ b/include/xeus/xhelper.hpp
@@ -67,6 +67,25 @@ namespace xeus
                                const std::string& banner = std::string(),
                                const bool debugger = false,
                                const nl::json& help_links = nl::json::object());
+
+    struct XEUS_API xinfo_reply
+    {
+      std::string  protocol_version;
+      std::string  implementation;
+      std::string  implementation_version;
+      std::string  language_name;
+      std::string  language_version;
+      std::string  language_mimetype;
+      std::string  language_file_extension;
+      std::string  pygments_lexer;
+      std::string  language_codemirror_mode;
+      std::string  language_nbconvert_exporter;
+      std::string  banner;
+      bool         debugger {false};     
+      nl::json     help_links{ nl::json::object()};
+      
+      operator nl::json() const;
+    };
 }
 
 #endif

--- a/src/xhelper.cpp
+++ b/src/xhelper.cpp
@@ -151,5 +151,24 @@ namespace xeus
         return kernel_res;
     }
 
+
+    xinfo_reply:: operator nl::json() const 
+    {
+        return create_info_reply(
+            this->protocol_version,
+            this->implementation,
+            this->implementation_version,
+            this->language_name,
+            this->language_version,
+            this->language_mimetype,
+            this->language_file_extension,
+            this->pygments_lexer,
+            this->language_codemirror_mode,
+            this->language_nbconvert_exporter,
+            this->banner,
+            this->debugger,
+            this->help_links
+        );
+    }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ find_program(PYTEST
 set(XEUS_TESTS
     test_xin_memory_history_manager.cpp
     test_unit_kernel.cpp
+    test_helper.cpp
 )
 
 if(nlohmann_json_FOUND)

--- a/test/test_helper.cpp
+++ b/test/test_helper.cpp
@@ -1,0 +1,49 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "doctest/doctest.h"
+
+#include <vector>
+#include <array>
+#include <string>
+
+#include "xeus/xhelper.hpp"
+#include "nlohmann/json.hpp"
+
+
+
+namespace nl = nlohmann;
+
+namespace xeus
+{
+
+
+    // template<class ... ARGS>
+    // class 
+
+
+    TEST_SUITE("xhelper"){
+        TEST_CASE("test_json_conversion")
+        {
+            xeus::xinfo_reply info_reply;
+            info_reply.protocol_version = "";
+            info_reply.implementation = "cpp_test";
+            info_reply.implementation_version = "1.0.0";
+            info_reply.language_name = "cpp";
+            info_reply.language_version = "14.0.0";
+            info_reply.language_mimetype = "text/c-c++src";
+            info_reply.language_file_extension = ".cpp";
+            info_reply.pygments_lexer = "";
+            info_reply.language_codemirror_mode = "";
+            info_reply.language_nbconvert_exporter = "";
+            info_reply.banner = "test_kernel";
+            info_reply.debugger = false;
+            nl::json json =  info_reply;
+        }
+    }
+}

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -96,17 +96,20 @@ namespace test_kernel
 
     nl::json test_interpreter::kernel_info_request_impl()
     {
-        return xeus::create_info_reply("",
-                                       "cpp_test",
-                                       "1.0.0",
-                                       "cpp",
-                                       "14.0.0",
-                                       "text/x-c++src",
-                                       ".cpp",
-                                       "",
-                                       "",
-                                       "",
-                                       "test_kernel");
+        xeus::xinfo_reply info_reply;
+        info_reply.protocol_version = "";
+        info_reply.implementation = "cpp_test";
+        info_reply.implementation_version = "1.0.0";
+        info_reply.language_name = "cpp";
+        info_reply.language_version = "14.0.0";
+        info_reply.language_mimetype = "text/c-c++src";
+        info_reply.language_file_extension = ".cpp";
+        info_reply.pygments_lexer = "";
+        info_reply.language_codemirror_mode = "";
+        info_reply.language_nbconvert_exporter = "";
+        info_reply.banner = "test_kernel";
+        info_reply.debugger = false;
+        return info_reply;
     }
 
     void test_interpreter::shutdown_request_impl()


### PR DESCRIPTION
I find this struct based helper classes more reable and less error prone than the function based helper classes

With struct:
```c++
xeus::xinfo_reply info_reply;
info_reply.protocol_version = "";
info_reply.implementation = "cpp_test";
info_reply.implementation_version = "1.0.0";
info_reply.language_name = "cpp";
info_reply.language_version = "14.0.0";
info_reply.language_mimetype = "text/c-c++src";
info_reply.language_file_extension = ".cpp";
info_reply.pygments_lexer = "";
info_reply.language_codemirror_mode = "";
info_reply.language_nbconvert_exporter = "";
info_reply.banner = "test_kernel";
info_reply.debugger = false;
return info_reply;
```

With function as it is atm
```c++
  return xeus::create_info_reply("",
                                 "cpp_test",
                                 "1.0.0",
                                 "cpp",
                                 "14.0.0",
                                 "text/x-c++src",
                                 ".cpp",
                                 "",
                                 "",
                                 "",
                                 "test_kernel");
```