### PR TITLE
use json::array for help_links

### DIFF
--- a/include/xeus/xhelper.hpp
+++ b/include/xeus/xhelper.hpp
@@ -66,7 +66,7 @@ namespace xeus
                                const std::string& language_nbconvert_exporter = std::string(),
                                const std::string& banner = std::string(),
                                const bool debugger = false,
-                               const nl::json& help_links = nl::json::object());
+                               const nl::json& help_links = nl::json::array());
 }
 
 #endif


### PR DESCRIPTION
Use `json::array` instead of `json::dict` as default value to conform with the [messaging-protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-info).