### PR TITLE
xeus now needs at least C++14 for std::make_unique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,7 @@ macro(xeus_create_target target_name linkage output_name)
     # Compilation flags
     # =================
 
-    target_compile_features(${target_name} PRIVATE cxx_std_11)
+    target_compile_features(${target_name} PRIVATE cxx_std_14)
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
         CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR


### PR DESCRIPTION
It doesn't build otherwise on macOS / emscripten because `std::make_unique` is not available.