### PR TITLE
Suggestion for modular CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Conf
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
               ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibUUID.cmake
+              ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerWarnings.cmake
               DESTINATION ${XEUS_CMAKECONFIG_INSTALL_DIR})
 install(EXPORT ${PROJECT_NAME}-targets
         FILE ${PROJECT_NAME}Targets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ endif()
 # ================
 
 include(CheckCXXCompilerFlag)
+include(cmake/CompilerWarnings.cmake)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
@@ -367,12 +368,11 @@ macro(xeus_create_target target_name linkage output_name)
     # =================
 
     target_compile_features(${target_name} PRIVATE cxx_std_14)
+    xeus_target_add_compile_warnings(${target_name} OPTION_PREFIX XEUS)
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
         CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
         CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-
-        target_compile_options(${target_name} PUBLIC -Wunused-parameter -Wextra -Wreorder)
 
         if (NOT XEUS_DISABLE_ARCH_NATIVE)
             target_compile_options(${target_name} PUBLIC -march=native)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,0 +1,138 @@
+# Module to set default compiler warnings.
+#
+# File adapted from Jason Turner's cpp_starter_project
+# https://github.com/lefticus/cpp_starter_project/blob/master/cmake/CompilerWarnings.cmake
+# Using INTERFACE targets is not so desirable as they need to be installed when building
+# static libraries.
+
+function(xeus_target_add_compile_warnings target)
+    # Names of option parameters (without arguments)
+    set(options)
+    # Names of named parameters with a single argument
+    set(oneValueArgs OPTION_PREFIX)
+    # Names of named parameters with a multiple arguments
+    set(multiValueArgs)
+    cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(WARNINGS_AS_ERRORS_NAME ${ARG_OPTION_PREFIX}_WARNINGS_AS_ERRORS)
+    option(${WARNINGS_AS_ERRORS_NAME} "Treat compiler warnings as errors" OFF)
+
+    set(
+        msvc_warnings
+        # Baseline reasonable warnings
+        /W4
+        # "identfier": conversion from "type1" to "type1", possible loss of data
+        /w14242
+        # "operator": conversion from "type1:field_bits" to "type2:field_bits", possible loss of
+        # data
+        /w14254
+        # "function": member function does not override any base class virtual member function
+        /w14263
+        # "classname": class has virtual functions, but destructor is not virtual instances of this
+        # class may not be destructed correctly
+        /w14265
+        # "operator": unsigned/negative constant mismatch
+        /w14287
+        # Nonstandard extension used: "variable": loop control variable declared in the for-loop is
+        # used outside the for-loop scope
+        /we4289
+        # "operator": expression is always "boolean_value"
+        /w14296
+        # "variable": pointer truncation from "type1" to "type2"
+        /w14311
+        # Expression before comma evaluates to a function which is missing an argument list
+        /w14545
+        # Function call before comma missing argument list
+        /w14546
+        # "operator": operator before comma has no effect; expected operator with side-effect
+        /w14547
+        # "operator": operator before comma has no effect; did you intend "operator"?
+        /w14549
+        # Expression has no effect; expected expression with side- effect
+        /w14555
+        # Pragma warning: there is no warning number "number"
+        /w14619
+        # Enable warning on thread un-safe static member initialization
+        /w14640
+        # Conversion from "type1" to "type_2" is sign-extended. This may cause unexpected runtime
+        # behavior.
+        /w14826
+        # Wide string literal cast to "LPSTR"
+        /w14905
+        # String literal cast to "LPWSTR"
+        /w14906
+        # Illegal copy-initialization; more than one user-defined conversion has been implicitly
+        # applied
+        /w14928
+    )
+
+    set(
+        clang_warnings
+        # Some default set of warnings
+        -Wall
+        # Reasonable and standard
+        -Wextra
+        # Warn the user if a variable declaration shadows one from a parent context
+        -Wshadow
+        # Warn the user if a class with virtual functions has a non-virtual destructor. This helps
+        # catch hard to track down memory errors
+        -Wnon-virtual-dtor
+        # Warn for c-style casts
+        -Wold-style-cast
+        # Warn for potential performance problem casts
+        -Wcast-align
+        # Warn on anything being unused
+        -Wunused
+        # Warn if you overload (not override) a virtual function
+        -Woverloaded-virtual
+        # Warn if non-standard C++ is used
+        -Wpedantic
+        # Warn on type conversions that may lose data
+        -Wconversion
+        # Warn on sign conversions
+        -Wsign-conversion
+        # Warn if a null dereference is detected
+        -Wnull-dereference
+        # Warn if float is implicit promoted to double
+        -Wdouble-promotion
+        # Warn on security issues around functions that format output (ie printf)
+        -Wformat=2
+        # Warn on code that cannot be executed
+        -Wunreachable-code
+        # Warn if a variable is used before being initialized
+        -Wuninitialized
+    )
+
+    if(${WARNINGS_AS_ERRORS_NAME})
+        set(clang_warnings ${clang_warnings} -Werror)
+        set(msvc_warnings ${msvc_warnings} /WX)
+    endif()
+
+    set(
+        gcc_warnings
+        ${clang_warnings}
+        # Warn if identation implies blocks where blocks do not exist
+        -Wmisleading-indentation
+        # Warn if if / else chain has duplicated conditions
+        -Wduplicated-cond
+        # Warn if if / else branches have duplicated code
+        -Wduplicated-branches
+        # Warn about logical operations being used where bitwise were probably wanted
+        -Wlogical-op
+        # Warn if you perform a cast to the same type
+        -Wuseless-cast
+    )
+
+    if(MSVC)
+        set(warnings ${msvc_warnings})
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        set(warnings ${clang_warnings})
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(warnings ${clang_warnings})
+    else()
+        set(warnings ${gcc_warnings})
+    endif()
+
+    target_compile_options("${target}" PRIVATE ${warnings})
+
+endfunction()


### PR DESCRIPTION
This is a suggestion on how to make CMake scripts more modular.

The files `CompilerWarnings.cmake` is included to provide an a fuction `xeus_target_add_compile_warnings`.
The file can be used in Xeus itself and in all Xeus kernels.
It is (TODO) installed under Xeus cmake install directory, as commonly done by various CMake project, to avoid clash with other CMake files.

The function takes an argument `OPTION_PREFIX` to avoid using the same option name everywhere.
In Xeus, it is used with `OPTION_PREFIX XEUS` to define the option `XEUS_WARNINGS_AS_ERRORS` but a project, say Xeus-Python, would use with `OPTION_PREFIX XEUS_PYTHON` to use the option `XEUS_PYTHON_WARNINGS_AS_ERRORS`.
It is also a function rather than a macro so isolate better its variables.

In this example, it changes little to Xeus CMake scripts, but it showcase how we can make CMake components for various functions (architecture, static builds, wasm, lto, sanitizers, *etc*.).
Contrary to the cookie-cutter approach, it is **not templated**, modular, and easy to update for kernels.