### PR TITLE
unify wasm options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v1
 
-        - name: Install mamba
+      - name: install mamba
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v1
 
-      - name: install mamba
+        - name: Install mamba
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "xeus binary version: v${XEUS_BINARY_VERSION}")
 option(XEUS_BUILD_SHARED_LIBS "Build xeus shared library." ON)
 option(XEUS_BUILD_STATIC_LIBS "Build xeus static library (default if BUILD_SHARED_LIBS is OFF)." ON)
 option(XEUS_STATIC_DEPENDENCIES "link statically with xeus dependencies" OFF)
-option(XEUS_EMSCRIPTEN_WASM_BUILD  "build for wasm via emscripten" OFF)
+# option(XEUS_EMSCRIPTEN_WASM_BUILD  "build for wasm via emscripten" OFF)
 
 # Test options
 option(XEUS_BUILD_TESTS "xeus test suite" OFF)
@@ -59,7 +59,7 @@ option(XEUS_BUILD_TESTS "xeus test suite" OFF)
 # Emscripten wasm build configuration
 # ===================================
 
-if(XEUS_EMSCRIPTEN_WASM_BUILD)
+if(EMSCRIPTEN)
     SET(XEUS_BUILD_SHARED_LIBS OFF)
     SET(XEUS_BUILD_STATIC_LIBS ON)
 endif()
@@ -70,7 +70,7 @@ endif()
 message(STATUS "XEUS_BUILD_SHARED_LIBS:          ${XEUS_BUILD_SHARED_LIBS}")
 message(STATUS "XEUS_BUILD_STATIC_LIBS:          ${XEUS_BUILD_STATIC_LIBS}")
 message(STATUS "XEUS_STATIC_DEPENDENCIES:        ${XEUS_STATIC_DEPENDENCIES}")  
-message(STATUS "XEUS_EMSCRIPTEN_WASM_BUILD:      ${XEUS_EMSCRIPTEN_WASM_BUILD}")
+message(STATUS "XEUS_EMSCRIPTEN_WASM_BUILD:      ${EMSCRIPTEN}")
 message(STATUS "XEUS_BUILD_TESTS:                ${XEUS_BUILD_TESTS}")  
 
 # Dependencies
@@ -169,7 +169,7 @@ macro(xeus_create_target target_name linkage output_name)
         PUBLIC xtl
     )
 
-    if (NOT MSVC AND NOT XEUS_EMSCRIPTEN_WASM_BUILD)
+    if (NOT MSVC AND NOT EMSCRIPTEN)
         if (APPLE)
             target_link_libraries(${target_name} PUBLIC "-framework CoreFoundation")
         else ()
@@ -251,7 +251,7 @@ macro(xeus_create_target target_name linkage output_name)
         endif ()
     endif ()
 
-    if (XEUS_EMSCRIPTEN_WASM_BUILD)
+    if (EMSCRIPTEN)
        target_compile_definitions(${target_name} PRIVATE XEUS_EMSCRIPTEN_WASM_BUILD)
        xeus_wasm_compile_options(${target_name})
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ message(STATUS "xeus binary version: v${XEUS_BINARY_VERSION}")
 option(XEUS_BUILD_SHARED_LIBS "Build xeus shared library." ON)
 option(XEUS_BUILD_STATIC_LIBS "Build xeus static library (default if BUILD_SHARED_LIBS is OFF)." ON)
 option(XEUS_STATIC_DEPENDENCIES "link statically with xeus dependencies" OFF)
-# option(XEUS_EMSCRIPTEN_WASM_BUILD  "build for wasm via emscripten" OFF)
 
 # Test options
 option(XEUS_BUILD_TESTS "xeus test suite" OFF)

--- a/cmake/WasmBuildOptions.cmake
+++ b/cmake/WasmBuildOptions.cmake
@@ -37,19 +37,8 @@ function(xeus_wasm_link_options target environment)
         PUBLIC "SHELL: -s TOTAL_STACK=32mb"
         PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
         PUBLIC "SHELL: -s WASM_BIGINT"
-    )
-endfunction()
-
-function(xeus_wasm_fs_options target)
-    target_link_options("${target}"
         PUBLIC "SHELL: -s FORCE_FILESYSTEM"
-    )
-endfunction()
-
-function(xeus_wasm_async_options target)
-    target_link_options("${target}"
-        INTERFACE "SHELL: -s ASYNCIFY=1"
-        INTERFACE "SHELL: -s 'ASYNCIFY_IMPORTS=[\"get_stdin\"]'"
-        INTERFACE "SHELL: -s 'ASYNCIFY_STACK_SIZE=100000'"
+        PUBLIC "SHELL: -s MAIN_MODULE=1"
+        PUBLIC "SHELL: -s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=\"['\$Browser', '\$ERRNO_CODES']\" "
     )
 endfunction()

--- a/cmake/WasmBuildOptions.cmake
+++ b/cmake/WasmBuildOptions.cmake
@@ -16,6 +16,7 @@ function(xeus_wasm_compile_options target)
         PUBLIC "SHELL: -s USE_PTHREADS=0"
         PUBLIC "SHELL: -fexceptions"
     )
+    set_property(TARGET ${target} PROPERTY POSITION_INDEPENDENT_CODE ON)
 endfunction()
 
 function(xeus_wasm_link_options target environment)
@@ -39,6 +40,5 @@ function(xeus_wasm_link_options target environment)
         PUBLIC "SHELL: -s WASM_BIGINT"
         PUBLIC "SHELL: -s FORCE_FILESYSTEM"
         PUBLIC "SHELL: -s MAIN_MODULE=1"
-        PUBLIC "SHELL: -s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=\"['\$Browser', '\$ERRNO_CODES']\" "
     )
 endfunction()


### PR DESCRIPTION
See https://github.com/jupyter-xeus/xeus-lite/issues/7 for details, but in a nutshell, we want all xeus-wasm kernels to be as similar / unified as we can. Therefore we:
* drop the async option from the wasm options. If a kernel really wants to be async, the flag can be set in the kernel directly.
* **force** all kernels to use _[dynamic linking](https://emscripten.org/docs/compiling/Dynamic-Linking.html#dynamic-linking)_ (even though atm this is only used by python, most kernels should use that, in particular lua and any upcoming R kernel)

In **this PR** we:
* drop the async option function
* added the needed flags for dynamic linking (`MAIN_MODULE`)
* removed the filesystem option and just force a filesystem for all kernels
* add `POSITION_INDEPENDENT_CODE` flag for all kernels, ie `-fPIC`, since this is mandatory for all used libraries when using dynamic linking. 
* remove superfluous flag `XEUS_EMSCRIPTEN_WASM_BUILD` to indicate emscripten build, we can just use `EMSCRIPTEN` which already does the job. 