### PR TITLE
Replace function pointers

### DIFF
--- a/include/xeus/xkernel.hpp
+++ b/include/xeus/xkernel.hpp
@@ -20,6 +20,7 @@
 #include "xlogger.hpp"
 #include <memory>
 #include <string>
+#include <functional>
 
 namespace xeus
 {
@@ -39,9 +40,9 @@ namespace xeus
         using logger_ptr = std::unique_ptr<xlogger>;
         using server_ptr = std::unique_ptr<xserver>;
         using debugger_ptr = std::unique_ptr<xdebugger>;
-        using server_builder = server_ptr (*)(xcontext& context,
-                                              const xconfiguration& config,
-                                              nl::json::error_handler_t eh);
+        using server_builder = std::function<server_ptr(xcontext& context,
+                                             const xconfiguration& config,
+                                             nl::json::error_handler_t eh)>;
         using debugger_builder = debugger_ptr (*)(xcontext& context,
                                                   const xconfiguration& config,
                                                   const std::string&,

--- a/include/xeus/xkernel.hpp
+++ b/include/xeus/xkernel.hpp
@@ -43,11 +43,11 @@ namespace xeus
         using server_builder = std::function<server_ptr(xcontext& context,
                                              const xconfiguration& config,
                                              nl::json::error_handler_t eh)>;
-        using debugger_builder = debugger_ptr (*)(xcontext& context,
-                                                  const xconfiguration& config,
-                                                  const std::string&,
-                                                  const std::string&,
-                                                  const nl::json&);
+        using debugger_builder = std::function<debugger_ptr(xcontext& context,
+                                                const xconfiguration& config,
+                                                const std::string&,
+                                                const std::string&,
+                                                const nl::json&)>;
 
         xkernel(const xconfiguration& config,
                 const std::string& user_name,


### PR DESCRIPTION
Replacing the function pointers with `std::function`s to be able to pass lambda functions with captured values when creating the server or the debugger.