### PR TITLE
Required same version of nlohmann_json in dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,12 @@ message(STATUS "XEUS_BUILD_TESTS:                ${XEUS_BUILD_TESTS}")
 # Dependencies
 # ============
 
-set(nlohmann_json_REQUIRED_VERSION 3.2.0)
+# nlohmann_json requires libraries that exchange json objects to be linked
+# with the same version of nlohmann_json. Therefore this version should be
+# the same in all xeus components; to do so, downstream projects should not
+# search # directly for nlohmann_json, but rely on find_dependency called by
+# find_package(xeus) instead.
+set(nlohmann_json_REQUIRED_VERSION 3.11)
 set(xtl_REQUIRED_VERSION 0.7)
 
 if (NOT TARGET nlohmann_json)

--- a/xeusConfig.cmake.in
+++ b/xeusConfig.cmake.in
@@ -23,7 +23,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 
 include(CMakeFindDependencyMacro)
 find_dependency(xtl @xtl_REQUIRED_VERSION@)
-find_dependency(nlohmann_json @nlohmann_json_REQUIRED_VERSION@)
+# nlohmann_json requires libraries that exchange json objects to be linked
+# with the same version of nlohmann_json. 
+find_dependency(nlohmann_json @nlohmann_json_REQUIRED_VERSION@ EXACT)
 
 # This is required when linking with the static target
 if(NOT EMSCRIPTEN)


### PR DESCRIPTION
Fixes #381.
~~Should be updated and marked as "ready for review" when nlohmann_json 3.11.3 is available on conda-forge, to avoid breaking debian and emscripten packages.~~