### PR TITLE
Local copy of header in dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,12 @@ set(xtl_REQUIRED_VERSION 0.7)
 
 if (NOT TARGET nlohmann_json)
     find_package(nlohmann_json ${nlohmann_json_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found nlohmann_json ${nlohmann_json_VERSION}")
 endif ()
 
 if (NOT TARGET xtl)
     find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found xl ${xtl_VERSION}")
 endif ()
 
 # Source files

--- a/src/xkernel_core.cpp
+++ b/src/xkernel_core.cpp
@@ -190,7 +190,9 @@ namespace xeus
     void xkernel_core::dispatch(xmessage msg, channel c)
     {
         p_logger->log_received_message(msg, c == channel::SHELL ? xlogger::shell : xlogger::control);
-        const nl::json& header = msg.header();
+        // Copy because the msg is moved after, and we may need the header
+        // for publishing the status.
+        nl::json header = msg.header();
         publish_status(header, "busy", c);
 
         std::string msg_type = header.value("msg_type", "");


### PR DESCRIPTION
This fixes the empty parent header issue of IDLE status messages for blocking handlers.