### PR TITLE
Fix extract_filename function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v2
 
       - name: Install mamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-dev.yml
           environment-name: xeus
@@ -91,9 +91,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install mamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
           environment-file: environment-dev.yml
           environment-name: xeus
           init-shell: cmd.exe
@@ -145,7 +144,7 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v2
 
       - name: Install mamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-wasm-build.yml
           environment-name: xeus-wasm-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Install mamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: environment-dev.yml
           environment-name: xeus
           init-shell: cmd.exe

--- a/include/xeus/xhelper.hpp
+++ b/include/xeus/xhelper.hpp
@@ -24,7 +24,7 @@ namespace xeus
 {
     XEUS_API std::string get_start_message(const xconfiguration& config);
 
-    XEUS_API std::string extract_filename(int argc, char* argv[]);
+    XEUS_API std::string extract_filename(int &argc, char* argv[]);
 
     XEUS_API bool should_print_version(int argc, char* argv[]);
 

--- a/src/xhelper.cpp
+++ b/src/xhelper.cpp
@@ -30,7 +30,7 @@ namespace xeus
         return kernel_info;
     }
 
-    std::string extract_filename(int argc, char* argv[])
+    std::string extract_filename(int &argc, char* argv[])
     {
         std::string res = "";
         for (int i = 0; i < argc; ++i)

--- a/test/test_unit_kernel.cpp
+++ b/test/test_unit_kernel.cpp
@@ -55,11 +55,13 @@ namespace xeus
 
         TEST_CASE("extract_filename")
         {
+            int argc = 3;
             char* argv[2];
             argv[0] = (char*)"-f";
             argv[1] = (char*)"connection.json";
-            std::string file_name = extract_filename(3, argv);
+            std::string file_name = extract_filename(argc, argv);
             REQUIRE_EQ(file_name, "connection.json");
+            REQUIRE_EQ(argc, 1);
         }
 
         TEST_CASE("should_print_version")


### PR DESCRIPTION
If the `extract_filename` function is going to be editing `argv`, then it also needs to make a corresponding change to `argc`.

I thought this would work right out off the bat when I was using it for xeus-cpp but it ends up giving me errors (shown in this PR https://github.com/compiler-research/xeus-cpp/pull/153)