### PR TITLE
Update wasm flags

### DIFF
--- a/cmake/WasmBuildOptions.cmake
+++ b/cmake/WasmBuildOptions.cmake
@@ -13,7 +13,6 @@ function(xeus_wasm_compile_options target)
      target_compile_options("${target}"
         PUBLIC --std=c++17
         PUBLIC -Wno-deprecated
-        PUBLIC "SHELL: -s USE_PTHREADS=0"
         PUBLIC "SHELL: -fexceptions"
     )
     set_property(TARGET ${target} PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -33,9 +32,8 @@ function(xeus_wasm_link_options target environment)
         PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
         PUBLIC "SHELL: -s EXIT_RUNTIME=1"
         PUBLIC "SHELL: -s WASM=1"
-        PUBLIC "SHELL: -s USE_PTHREADS=0"
         PUBLIC "SHELL: -s ENVIRONMENT=${environment}"
-        PUBLIC "SHELL: -s TOTAL_STACK=32mb"
+        PUBLIC "SHELL: -s STACK_SIZE=32mb"
         PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
         PUBLIC "SHELL: -s WASM_BIGINT"
         PUBLIC "SHELL: -s FORCE_FILESYSTEM"


### PR DESCRIPTION
Fixes:

```
warning: use of legacy setting: TOTAL_STACK (setting renamed to STACK_SIZE) 

warning: use of legacy setting: USE_PTHREADS (No longer needed. Use -pthread instead) 
```

> By default, support for pthreads is not enabled. ([source](https://emscripten.org/docs/porting/pthreads.html))