### PR TITLE
Use EXPORTED_RUNTIME_METHODS to prevent runtime errors on xeus-lite kernels

### DIFF
--- a/cmake/WasmBuildOptions.cmake
+++ b/cmake/WasmBuildOptions.cmake
@@ -36,6 +36,7 @@ function(xeus_wasm_link_options target environment)
         PUBLIC "SHELL: -s STACK_SIZE=32mb"
         PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
         PUBLIC "SHELL: -s WASM_BIGINT"
+        PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS='[\"FS\",\"PATH\",\"LDSO\",\"getDylinkMetadata\",\"loadDynamicLibrary\",\"ERRNO_CODES\"]'"
         PUBLIC "SHELL: -s FORCE_FILESYSTEM"
         PUBLIC "SHELL: -s MAIN_MODULE=1"
     )


### PR DESCRIPTION
On xues-cpp-lite (and on other xeus-lite kernels we see these following )

![image](https://github.com/user-attachments/assets/6f377d9c-dce0-46b3-a129-c1c781d79f97)

![image](https://github.com/user-attachments/assets/7904713f-b352-43f1-a388-3e962da18cee)

![image](https://github.com/user-attachments/assets/d1aa4310-0e3e-422f-ae90-8c7236e5bb63)

This PR should address these errors.