### PR TITLE
Update Emscripten CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,28 +151,31 @@ jobs:
           create-args: libuuid
 
       - name: Setup emsdk
-        run: emsdk install ${{ matrix.emsdk_ver }}
+        shell: bash -l {0}
+        run: |
+          cd $HOME
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install  ${{ matrix.emsdk_ver }}
 
       - name: Build and package xeus
         run: |
-          emsdk activate ${{ matrix.emsdk_ver }}
-          source $CONDA_EMSDK_DIR/emsdk_env.sh
+          $HOME/emsdk/emsdk activate ${{matrix.emsdk_ver}}
+          source $HOME/emsdk/emsdk_env.sh
 
           micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 
           mkdir build
           pushd build
 
-          export EMPACK_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-wasm-build
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-wasm-host
           export CMAKE_PREFIX_PATH=$PREFIX
           export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
 
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON \
+            -DCMAKE_FIND_ROOT_PATH=$PREFIX \
             -DXEUS_EMSCRIPTEN_WASM_BUILD=ON \
-            -Dnlohmann_json_DIR=$MAMBA_ROOT_PREFIX/share/cmake/nlohmann_json \
             ..
 
           make -j${{ steps.cpu-cores.outputs.count }}

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -3,6 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - emsdk >=3.1.11
-  - empack >=2.0.1
 


### PR DESCRIPTION
1) Clones emsdk and uses it rather than fetching emsdk from conda-forge (just like xeus-python, xeus-cpp etc)

2) I think `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE` is being used wrongly.

[Cmake docs](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_ROOT_PATH_MODE_PACKAGE.html#variable:CMAKE_FIND_ROOT_PATH_MODE_PACKAGE) say that there are only 3 values this variables accepts

i) ONLY
ii) NEVER
iii) BOTH

What we are using is something like `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON` which doesn't make sense.

As the docs say `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE` basically controls two variables
i) `CMAKE_FIND_ROOT_PATH`
ii) `CMAKE_SYSROOT`

As far as my understanding goes we just need to control the `CMAKE_FIND_ROOT_PATH` that cmake uses while cross-compiling.

When cross-compiling (for example, when using Emscripten), CMake normally uses the host system's root directory as the search root. `CMAKE_FIND_ROOT_PATH` allows you to override this behaviour and specify alternate directories that CMake should treat as the root for package discovery.

So in this case we don't even need to control both vars through `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE` as `CMAKE_SYSROOT` is not really of use to us.

