### PR TITLE
Remove `USE_ES6_IMPORT_META` setting that is no longer supported

### DIFF
--- a/cmake/WasmBuildOptions.cmake
+++ b/cmake/WasmBuildOptions.cmake
@@ -26,7 +26,6 @@ function(xeus_wasm_link_options target environment)
         PUBLIC "SHELL: -s MODULARIZE=1"
         PUBLIC "SHELL: -s EXPORT_NAME=\"createXeusModule\""
         PUBLIC "SHELL: -s EXPORT_ES6=0"
-        PUBLIC "SHELL: -s USE_ES6_IMPORT_META=0"
         PUBLIC "SHELL: -s ASSERTIONS=0"
         PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
         PUBLIC "SHELL: -s EXIT_RUNTIME=1"


### PR DESCRIPTION
The `WasmBuildOptions` setting `USE_ES6_IMPORT_META` is no longer supported as of emscripten 4.0.4 (https://github.com/emscripten-core/emscripten/blob/c2d94c86c9e977b2a772e8364783ebf158914322/ChangeLog.md?plain=1#L77). We cannot currently build `jupyter-xeus/xeus-lite` with latest emscripten due to this unrecognised setting. Here removing the setting so that we can check if downstream is happy without it or not.