### PR TITLE
Use `password` not `pwd` in `input_request` message

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -257,7 +257,7 @@ namespace xeus
         {
             nl::json content;
             content["prompt"] = prompt;
-            content["pwd"] = pwd;
+            content["password"] = pwd;
             m_stdin(
                 get_request_context(),
                 "input_request",


### PR DESCRIPTION
Use `password` not `pwd` in `input_request` message to correctly follow Jupyter protocol. Fixes #427.