### PR TITLE
Remove 'getDylinkMetadata' from exported methods

### DIFF
--- a/cmake/WasmBuildOptions.cmake
+++ b/cmake/WasmBuildOptions.cmake
@@ -34,7 +34,7 @@ function(xeus_wasm_link_options target environment)
         PUBLIC "SHELL: -s STACK_SIZE=32mb"
         PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
         PUBLIC "SHELL: -s WASM_BIGINT"
-        PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS='[\"FS\",\"ENV\",\"PATH\",\"LDSO\",\"getDylinkMetadata\",\"loadDynamicLibrary\",\"ERRNO_CODES\"]'"
+        PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS='[\"FS\",\"ENV\",\"PATH\",\"LDSO\",\"loadDynamicLibrary\",\"ERRNO_CODES\"]'"
         PUBLIC "SHELL: -s FORCE_FILESYSTEM"
         PUBLIC "SHELL: -s MAIN_MODULE=1"
     )


### PR DESCRIPTION
I tried to build xeus-ocaml with  Emscripten 4x, but it throws error with undefined method.

It may be [redundant](https://github.com/jupyter-xeus/xeus/pull/433#issue-3546336425) with MAIN_MODULE=1 

Anyway, without it it builds and works fine, and and so does it with emscripten 3.73.